### PR TITLE
Add pagination for clienti and clienti search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,15 @@
    		 	<version>5.1.3</version>
 		</dependency>
 		
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+		    <groupId>org.projectlombok</groupId>
+		    <artifactId>lombok</artifactId>
+		    <version>1.18.36</version>
+		    <scope>provided</scope>
+		</dependency>
+
+		
 		<dependency>
  			<groupId>org.springframework.boot</groupId>
  			<artifactId>spring-boot-starter-validation</artifactId>
@@ -70,6 +79,12 @@
     		<version>3.3.4</version>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.springframework.data/spring-data-commons -->
+		<dependency>
+		    <groupId>org.springframework.data</groupId>
+		    <artifactId>spring-data-commons</artifactId>
+		    <version>3.4.0</version>
+		</dependency>
 			
 	</dependencies>
 

--- a/src/main/java/com/freelapp/controller/ApiRestController.java
+++ b/src/main/java/com/freelapp/controller/ApiRestController.java
@@ -1,0 +1,29 @@
+package com.freelapp.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.freelapp.model.Cliente;
+import com.freelapp.repository.ClienteRepository;
+
+@RestController
+@CrossOrigin
+@RequestMapping("/api")
+public class ApiRestController {
+	
+	@Autowired
+	private ClienteRepository repositoryCliente;
+	
+	@GetMapping
+	public Page<Cliente> findAll(@RequestParam int page, @RequestParam int size){
+		PageRequest pageRequest = PageRequest.of(page, size);
+		return repositoryCliente.findAll(pageRequest);
+	}
+	
+}

--- a/src/main/java/com/freelapp/controller/ClientController.java
+++ b/src/main/java/com/freelapp/controller/ClientController.java
@@ -1,9 +1,14 @@
 package com.freelapp.controller;
 
-import java.util.ArrayList;
+
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+
+
+
+
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -15,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import com.freelapp.model.Cliente;
 import com.freelapp.repository.ClienteRepository;
+import com.freelapp.service.ClienteService;
 
 import jakarta.validation.Valid;
 
@@ -24,28 +30,82 @@ public class ClientController {
 	@Autowired
 	private ClienteRepository repositoryCliente;
 	
+	@Autowired
+	private ClienteService clienteService;
 	
-	 @GetMapping("/Clienti")
-	 public String listaClienti(Model model) {
 	
-		List<Cliente> listaClienti = repositoryCliente.findAll();
-		model.addAttribute("list", listaClienti);
+//	@GetMapping("/Clienti")
+//	public String listaClienti(Model model) {
+//		
+//		List<Cliente> listaClienti = repositoryCliente.findAll();
+//		
+//		model.addAttribute("list", listaClienti);
+//		
+//		return "/Clienti/listClient";
+//	} 
+	
+	@GetMapping("/Clienti")
+	public String listaClienti(Model model) {
+		
+		return getOnePage(1, model );
+	} 
+	
+	
+	@GetMapping("/Clienti/page/{pageNumber}")
+	public String getOnePage(@PathVariable("pageNumber") int currentPage, Model model ) {
+		
+		Page<Cliente> page = clienteService.findPage(currentPage);
+		
+		int totalPages = page.getTotalPages();
+		
+		long totalItems = page.getTotalElements();
+		
+		List<Cliente> listClienti = page.getContent();
+		
+		model.addAttribute("list", listClienti);
+		
+		model.addAttribute("currentPage", currentPage);
+	
+		model.addAttribute("totalPages", totalPages);
+		
+		model.addAttribute("totalItems", totalItems);
+		
 		return "/Clienti/listClient";
-	}
-	 
-	 @GetMapping("/cliente-search")
-	 public String clienteByPartitaIva(@Param("input") String input, Model model) {
+	} 
+	
+	@GetMapping("/cliente-search")
+	public String listaClientiSearch(@Param("input") String input,Model model) {
+		
+		return clienteBySearch(1, input, model);
+	} 
+		 
+	 @GetMapping("/cliente-search/page/{numberPage}")
+	 public String clienteBySearch(@PathVariable("pageNumber") int currentPage, String input,
+			 	Model model) {
 
+//		 		List<Cliente> list = new ArrayList<Cliente>();
+//
+//				 if(!input.isEmpty()) {
+//					 
+//					 list = repositoryCliente.search(input);
+//					 
+//				 } 
+				 
+				 Page<Cliente> page = clienteService.findSearchedPage(currentPage,input);
 
-				List<Cliente> list = new ArrayList<Cliente>();
+				 int totalPages = page.getTotalPages();
+				 
+				 long totalItems = page.getTotalElements();
+				 
+				 List<Cliente> listaClientiSearch = page.getContent();
 				
-				if(!input.isEmpty()) {
-					
-					list = repositoryCliente.search(input);
-					
-				} 
-					
-				model.addAttribute("list", list);	
+				model.addAttribute("currentPage", currentPage);
+			
+				model.addAttribute("totalPages", totalPages);
+				
+				model.addAttribute("totalItems", totalItems);
+				
+				model.addAttribute("list", listaClientiSearch);	
 				
 				return "Clienti/listClient";
 		 
@@ -126,6 +186,8 @@ public class ClientController {
 		
 		return "redirect:/Clienti";
 	  }
+
+	
 }
 	
 

--- a/src/main/java/com/freelapp/repository/ClienteRepository.java
+++ b/src/main/java/com/freelapp/repository/ClienteRepository.java
@@ -2,12 +2,15 @@ package com.freelapp.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 import com.freelapp.model.Cliente;
 
-public interface ClienteRepository extends JpaRepository<Cliente, Integer>{
+public interface ClienteRepository extends JpaRepository<Cliente, Integer>, PagingAndSortingRepository<Cliente, Integer>{
 	
 
     @Query("SELECT c FROM Cliente c WHERE c.name LIKE '%'||:input||'%' OR "
@@ -17,5 +20,10 @@ public interface ClienteRepository extends JpaRepository<Cliente, Integer>{
     		+ "c.indirizzo LIKE '%'||:input||'%' OR "
     		+ "c.city LIKE '%'||:input||'%' OR "
     		+ "c.partitaIva LIKE '%'||:input||'%' ")
-    public List<Cliente> search( String input);
+    public Page<Cliente> search( String input, Pageable pageable);
+    
+    public List<Cliente> findAll();
+    
+    
+   
 }

--- a/src/main/java/com/freelapp/service/ClienteService.java
+++ b/src/main/java/com/freelapp/service/ClienteService.java
@@ -1,0 +1,37 @@
+package com.freelapp.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+
+import com.freelapp.model.Cliente;
+import com.freelapp.repository.ClienteRepository;
+
+@Service
+public class ClienteService {
+	
+	@Autowired
+	private ClienteRepository clienteRepository;
+	
+	public List<Cliente> findAll(){
+		return clienteRepository.findAll();
+	}
+	
+	public Page<Cliente> findPage(int pageNumber){
+		Pageable pageable = PageRequest.of(pageNumber -1, 4);
+		return clienteRepository.findAll(pageable);
+		
+	}
+	
+	public Page<Cliente> findSearchedPage(int pageNumber, String input){
+		Pageable pageable = PageRequest.of(pageNumber -1, 4);
+		return clienteRepository.search(input, pageable);
+		
+	}
+
+
+}

--- a/src/main/resources/templates/Clienti/listClient.html
+++ b/src/main/resources/templates/Clienti/listClient.html
@@ -92,11 +92,21 @@
 	   <h1>La ricerca non ha prodotto risultati</h1>
    </div>
 </div>
-
+<div class="container">
+	<div class="row d-flex justify-content-between text-center">
+		<div class="col" th:text="|Clienti Totali: ${totalItems} - Pagina ${currentPage} di ${totalPages}|">	
+		</div>
+		<div class="col">
+			  <span class=" justify-content-center"
+			  	th:each="i : ${#numbers.sequence(1, totalPages)}">
+			    <a class="p-2" style="border: 1px solid grey; border-radius: 5px;" th:href="@{'/Clienti/page/'+${i}}" th:text="${i}"></a>
+			  </span>	
+		</div>
+	</div>
+</div>
 <div class="text-center mt-5 mb-5">
    <a th:fragment="button(link)" class="btn btn-success" th:href="@{/Clienti/insert}"> Inserisci un nuovo cliente </a>
 </div>
-
 <div class="container mt-5">
   	<div class="text-center mb-5">
   	  <form class="mx-auto w-50" role="search" method:"get" th:object="${Cliente}" th:action="@{/cliente-search}">
@@ -107,7 +117,12 @@
         </form>
       </div>  
     </div>
-
+	
+	<div>
+		<ul th:each="client : ${listClienti}">
+						<li th:text="${client.name}"></li>
+		</ul>
+	</div>
 <script th:src="@{/webjars/bootstrap/5.1.3/js/bootstrap.bundle.min.js}"></script>
 </body>
 </html>	 


### PR DESCRIPTION
Aggiunta paginazione dei clienti e della ricerca clienti (ho impostato al momento quattro clienti per pagina ma ovviamente questo è personalizzabile a piacimento). Alla fine per praticità d'uso ho preferito non usare l'API della paginazione ma un service. Ho però pensato di lasciare ugualmente il rest controller con l'API scritta perché magari potrebbe essere carino fornire anche una serie di API per ampliare il progetto.